### PR TITLE
Add support for Wayland sessions under Linux

### DIFF
--- a/cb
+++ b/cb
@@ -13,7 +13,9 @@ case "$OSTYPE$(uname)" in
           *) echo "unknown os=\"$OSTYPE$(uname)\"" >&2 ;;
 esac
 
+
 is_tux() { [ ${TUX_OS-0} -ne 0 ]; }
+is_wayland() { [ "$XDG_SESSION_TYPE" = 'wayland' ]; }
 is_mac() { [ ${MAC_OS-0} -ne 0 ]; }
 is_win() { [ ${WIN_OS-0} -ne 0 ]; }
 
@@ -27,8 +29,13 @@ elif is_win; then
   alias cbcopy=putclip
   alias cbpaste=getclip
 else
-  alias cbcopy='xclip -sel c'
-  alias cbpaste='xclip -sel c -o'
+  if is_wayland; then
+    alias cbcopy=wl-copy
+    alias cbpaste=wl-paste
+  else
+    alias cbcopy='xclip -sel c'
+    alias cbpaste='xclip -sel c -o'
+  fi
 fi
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Cutting-edge Linux distros like Fedora are moving toward using Wayland instead of Xorg, but that means that xclip, xsel, etc. are no longer reliably present on every install. 

Fortunately,  Wayland comes with `wl-copy` and `wl-paste`, which work as you'd expect. 

This PR adds Wayland detection via `$XDG_SESSION_TYPE`. When Wayland is detected, `wl-copy` and `wl-paste` are used as backend instead of `xclip`.

Notably, although I am a human, I am a human who tends to forget bash syntax, and I was assisted in the creation of this PR by ChatGPT, which (who?) kindly suggested the method of Wayland detection, inter alia. 

