### PR TITLE
update installation instructions to reference main branch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ command-c/v).
 
 ```bash
 # Download the script to ~/bin/cb.
-curl https://raw.githubusercontent.com/niedzielski/clipboard/master/cb -o ~/bin/cb &&
+curl https://raw.githubusercontent.com/niedzielski/clipboard/main/cb -o ~/bin/cb &&
 
 # Make the script executable.
 chmod +x ~/bin/cb


### PR DESCRIPTION
It looks like your default branch is `main`, but the readme includes a URL referencing the `master` branch.